### PR TITLE
Add thrown exceptions to callable info in symbol table

### DIFF
--- a/src/main/java/com/ibm/northstar/entities/Callable.java
+++ b/src/main/java/com/ibm/northstar/entities/Callable.java
@@ -9,6 +9,7 @@ public class Callable {
     private String comment;
     private List<String> annotations;
     private List<String> modifiers;
+    private List<String> thrownExceptions;
     private String declaration;
     private List<ParameterInCallable> parameters;
     private String code;


### PR DESCRIPTION
This PR:
- Adds a field for thrown exceptions (as resolved type names) to callable information in the symbol table
- Adds a check for illegal state exception during type resolution for expressions