### PR TITLE
Information about variable declarations in callables

### DIFF
--- a/src/main/java/com/ibm/northstar/entities/CallSite.java
+++ b/src/main/java/com/ibm/northstar/entities/CallSite.java
@@ -1,0 +1,16 @@
+package com.ibm.northstar.entities;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CallSite {
+    private String methodName;
+    private String declaringType;
+    private List<String> argumentTypes;
+    private int startLine;
+    private int startColumn;
+    private int endLine;
+    private int endColumn;
+}

--- a/src/main/java/com/ibm/northstar/entities/Callable.java
+++ b/src/main/java/com/ibm/northstar/entities/Callable.java
@@ -23,4 +23,5 @@ public class Callable {
     private List<String> accessedFields;
     private List<String> calledMethodDeclaringTypes;
     private List<CallSite> callSites;
+    private List<VariableDeclaration> variableDeclarations;
 }

--- a/src/main/java/com/ibm/northstar/entities/Callable.java
+++ b/src/main/java/com/ibm/northstar/entities/Callable.java
@@ -22,4 +22,5 @@ public class Callable {
     private List<String> referencedTypes;
     private List<String> accessedFields;
     private List<String> calledMethodDeclaringTypes;
+    private List<CallSite> callSites;
 }

--- a/src/main/java/com/ibm/northstar/entities/VariableDeclaration.java
+++ b/src/main/java/com/ibm/northstar/entities/VariableDeclaration.java
@@ -1,0 +1,16 @@
+package com.ibm.northstar.entities;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class VariableDeclaration {
+    private String name;
+    private String type;
+    private String initializer;
+    private int startLine;
+    private int startColumn;
+    private int endLine;
+    private int endColumn;
+}


### PR DESCRIPTION
- Created a new type to represent variable declarations, with information about name, type, initializer expression, and position
- Added variable declarations information to `Callable`
- Updated symbol table to add the new information

