### PR TITLE
Fix issue 87, 88, 90, and 91 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.8
+version=1.0.9-dev

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.9-dev
+version=1.0.9

--- a/src/main/java/com/ibm/cldk/utils/AnalysisUtils.java
+++ b/src/main/java/com/ibm/cldk/utils/AnalysisUtils.java
@@ -23,6 +23,7 @@ import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.impl.DefaultEntrypoint;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ssa.IR;
+import com.ibm.wala.ssa.ISSABasicBlock;
 import com.ibm.wala.ssa.SSAConditionalBranchInstruction;
 import com.ibm.wala.ssa.SSASwitchInstruction;
 import com.ibm.wala.types.ClassLoaderReference;
@@ -96,7 +97,11 @@ public class AnalysisUtils {
         int switchBranchCount = Arrays.stream(ir.getInstructions())
                 .filter(inst -> inst instanceof SSASwitchInstruction)
                 .map(inst -> ((SSASwitchInstruction) inst).getCasesAndLabels().length).reduce(0, Integer::sum);
-        return conditionalBranchCount + switchBranchCount + 1;
+        Iterable<ISSABasicBlock> iterableBasicBlocks = ir::getBlocks;
+        int catchBlockCount = (int) StreamSupport.stream(iterableBasicBlocks.spliterator(), false)
+                .filter(ISSABasicBlock::isCatchBlock)
+                .count();
+        return conditionalBranchCount + switchBranchCount + catchBlockCount + 1;
     }
 
     public static Pair<String, Callable> getCallableFromSymbolTable(IMethod method) {

--- a/src/main/java/com/ibm/cldk/utils/BuildProject.java
+++ b/src/main/java/com/ibm/cldk/utils/BuildProject.java
@@ -91,28 +91,9 @@ public class BuildProject {
     private static boolean commandExists(String command) {
         try {
             Process process = new ProcessBuilder().directory(new File(projectRootPom)).command(command, "--version").start();
-
-            // Read the output stream
-            BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream())
-            );
-            String line;
-            while ((line = reader.readLine()) != null) {
-                Log.info(line);
-            }
-
-            // Read the error stream
-            BufferedReader errorReader = new BufferedReader(
-                    new InputStreamReader(process.getErrorStream())
-            );
-            while ((line = errorReader.readLine()) != null) {
-                Log.info(line);
-            }
-
             int exitCode = process.waitFor();
             return exitCode == 0;
         } catch (IOException | InterruptedException exceptions) {
-            exceptions.printStackTrace();
             return false;
         }
     }

--- a/src/main/java/com/ibm/cldk/utils/BuildProject.java
+++ b/src/main/java/com/ibm/cldk/utils/BuildProject.java
@@ -54,7 +54,7 @@ public class BuildProject {
         String gradleWrapperExists = new File(projectRootPom, gradleWrapper).exists() ? "true" : "false";
 
         if (new File(projectRootPom, gradleWrapper).exists()) {
-            GRADLE_CMD = gradleWrapper;
+            GRADLE_CMD = String.valueOf(new File(projectRootPom, gradleWrapper));
         } else {
             GRADLE_CMD = gradle;
         }
@@ -112,6 +112,7 @@ public class BuildProject {
             int exitCode = process.waitFor();
             return exitCode == 0;
         } catch (IOException | InterruptedException exceptions) {
+            exceptions.printStackTrace();
             return false;
         }
     }

--- a/src/main/java/com/ibm/cldk/utils/BuildProject.java
+++ b/src/main/java/com/ibm/cldk/utils/BuildProject.java
@@ -90,7 +90,25 @@ public class BuildProject {
 
     private static boolean commandExists(String command) {
         try {
-            Process process = new ProcessBuilder(command, "--version").start();
+            Process process = new ProcessBuilder().directory(new File(projectRootPom)).command(command, "--version").start();
+
+            // Read the output stream
+            BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream())
+            );
+            String line;
+            while ((line = reader.readLine()) != null) {
+                Log.info(line);
+            }
+
+            // Read the error stream
+            BufferedReader errorReader = new BufferedReader(
+                    new InputStreamReader(process.getErrorStream())
+            );
+            while ((line = errorReader.readLine()) != null) {
+                Log.info(line);
+            }
+
             int exitCode = process.waitFor();
             return exitCode == 0;
         } catch (IOException | InterruptedException exceptions) {
@@ -100,7 +118,7 @@ public class BuildProject {
 
     private static boolean buildWithTool(String[] buildCommand) {
         Log.info("Building the project using " + buildCommand[0] + ".");
-        ProcessBuilder processBuilder = new ProcessBuilder(buildCommand);
+        ProcessBuilder processBuilder = new ProcessBuilder().directory(new File(projectRootPom)).command(buildCommand);
 
         try {
             Process process = processBuilder.start();
@@ -125,7 +143,7 @@ public class BuildProject {
      * @return true if Maven is installed, false otherwise.
      */
     private static boolean isMavenInstalled() {
-        ProcessBuilder processBuilder = new ProcessBuilder(MAVEN_CMD, "--version");
+        ProcessBuilder processBuilder = new ProcessBuilder().directory(new File(projectRootPom)).command(MAVEN_CMD, "--version");
         try {
             Process process = processBuilder.start();
             BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));

--- a/src/main/java/com/ibm/cldk/utils/BuildProject.java
+++ b/src/main/java/com/ibm/cldk/utils/BuildProject.java
@@ -228,7 +228,7 @@ public class BuildProject {
         if (pomFile.exists()) {
             Log.info("Found pom.xml in the project directory. Using Maven to download dependencies.");
             if (!commandExists(MAVEN_CMD))
-                throw new IllegalStateException("Could not find a valid maven command. I did not find " + MAVEN_CMD + " in the project directory or in the system PATH.");
+                throw new IllegalStateException("Could not find a valid maven command. Could not find " + MAVEN_CMD + " in the project directory or in the system PATH.");
 
             String[] mavenCommand = {
                     MAVEN_CMD, "--no-transfer-progress", "-f",
@@ -240,7 +240,7 @@ public class BuildProject {
         } else if (new File(projectRoot, "build.gradle").exists() || new File(projectRoot, "build.gradle.kts").exists()) {
             Log.info("Found build.gradle or build.gradle.kts in the project directory. Using gradle to download dependencies.");
             if (!commandExists(GRADLE_CMD))
-                throw new IllegalStateException("Could not find a valid Gradle command. I did not find " + GRADLE_CMD + " in the project directory or in the system PATH.");
+                throw new IllegalStateException("Could not find a valid Gradle command. Could not find " + GRADLE_CMD + " in the project directory or in the system PATH.");
 
             Log.info("Found build.gradle[.kts] in the project directory. Using Gradle to download dependencies.");
             tempInitScript = Files.writeString(tempInitScript, GRADLE_DEPENDENCIES_TASK);


### PR DESCRIPTION
This pull request add a static cyclomatic complexity computation (issue #91)  and fixed the mangled comments in constructor declarations (issue #90)

Also addressed issues #88 and #87. There, I found that when executing Maven wrapper using its absolute path (`/path/to/codeanalyzer-failing-projects/portfolio-spring/mvnw`), it was looking for just `.mvn/wrapper` files in the wrong working directory, causing a `ClassNotFoundException`.

I fixed this by splitting the absolute command path into directory and filename components. Now ProcessBuilder uses the command's parent directory as the working directory and the filename as the command.

```java
// Before: Using wrong working directory
Process process = new ProcessBuilder(command, "--version").start();

// After: Split command path to get correct working directory
Process process = new ProcessBuilder()
    .directory(new File(projectRootPom))  // Use mvnw's directory
    .command(commandFile.getName(), "--version")  // Use just "mvnw"
    .start();
```

I checked to make sure this applied to gradlew projects as well, and I made sure that the gradlew path is absolute.