### PR TITLE
Don't fail on build errors during download dependencies phase

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.9
+version=1.0.10

--- a/src/main/java/com/ibm/cldk/CodeAnalyzer.java
+++ b/src/main/java/com/ibm/cldk/CodeAnalyzer.java
@@ -118,11 +118,15 @@ public class CodeAnalyzer implements Runnable {
         } else {
             // download library dependencies of project for type resolution
             String dependencies = null;
-            if (BuildProject.downloadLibraryDependencies(input, projectRootPom)) {
+            try {if (BuildProject.downloadLibraryDependencies(input, projectRootPom)) {
                 dependencies = String.valueOf(BuildProject.libDownloadPath);
             } else {
                 Log.warn("Failed to download library dependencies of project");
             }
+            } catch (IllegalStateException illegalStateException) {
+                Log.warn("Failed to download library dependencies of project");
+            }
+
             boolean analysisFileExists = output != null && Files.exists(Paths.get(output + File.separator + outputFileName));
 
             // if target files are specified, compute symbol table information for the given files


### PR DESCRIPTION
This PR addresses issue #93, where we build `analysis.json` even when download dependencies fail. 

We catch the `IllegalStateException` thrown by potential `mvn[w]` or `gradle[w]` issues.

NOTE: When maven/gradle tools are malfunctioning, the actual build may still fail when you don't use `--no-build` flag, and codeanalyzer will fail with an exception. 