### PR TITLE
Fix issue 74

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.1.0
+version=1.1.1
 

--- a/src/main/java/com/ibm/cldk/CodeAnalyzer.java
+++ b/src/main/java/com/ibm/cldk/CodeAnalyzer.java
@@ -77,7 +77,7 @@ public class CodeAnalyzer implements Runnable {
     private static boolean verbose = false;
 
     @Option(names = {"--no-clean-dependencies"}, description = "Do not attempt to auto-clean dependencies")
-    public static boolean noCleanDependencies = true;
+    public static boolean noCleanDependencies = false;
 
     private static final String outputFileName = "analysis.json";
 

--- a/src/main/java/com/ibm/cldk/CodeAnalyzer.java
+++ b/src/main/java/com/ibm/cldk/CodeAnalyzer.java
@@ -76,6 +76,9 @@ public class CodeAnalyzer implements Runnable {
     @Option(names = {"-v", "--verbose"}, description = "Print logs to console.")
     private static boolean verbose = false;
 
+    @Option(names = {"--no-clean-dependencies"}, description = "Do not attempt to auto-clean dependencies")
+    public static boolean noCleanDependencies = true;
+
     private static final String outputFileName = "analysis.json";
 
     public static Gson gson = new GsonBuilder()

--- a/src/main/java/com/ibm/cldk/utils/BuildProject.java
+++ b/src/main/java/com/ibm/cldk/utils/BuildProject.java
@@ -274,14 +274,14 @@ public class BuildProject {
                 Files.walk(libDownloadPath).filter(Files::isRegularFile).map(Path::toFile).forEach(File::delete);
                 Files.delete(libDownloadPath);
             } catch (IOException e) {
-                Log.error("Error deleting library dependency directory: " + e.getMessage());
+                Log.warn("Unable to fully delete library dependency directory: " + e.getMessage());
             }
         }
         if (tempInitScript != null) {
             try {
                 Files.delete(tempInitScript);
             } catch (IOException e) {
-                Log.error("Error deleting temporary Gradle init script: " + e.getMessage());
+                Log.warn("Error deleting temporary Gradle init script: " + e.getMessage());
             }
         }
     }

--- a/src/main/java/com/ibm/cldk/utils/ProjectDirectoryScanner.java
+++ b/src/main/java/com/ibm/cldk/utils/ProjectDirectoryScanner.java
@@ -7,6 +7,8 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 public class ProjectDirectoryScanner {
     public static List<Path> classFilesStream(String projectPath) throws IOException {
@@ -35,6 +37,30 @@ public class ProjectDirectoryScanner {
             }
         }
         return null;
+    }
+
+    /**
+     * Returns a stream of class files inside the jars and class files in the project.
+     * @param projectPath
+     * @return
+     * @throws IOException
+     */
+    public static Stream<String> classesFromJarFileStream(String projectPath) throws IOException {
+        List<Path> jarPaths = jarFilesStream(projectPath);
+
+        if (jarPaths == null) {
+            return Stream.empty();
+        }
+
+        return jarPaths.stream().flatMap(jarPath -> {
+            try (ZipFile zip = new ZipFile(jarPath.toFile())) {
+                return zip.stream()
+                        .filter(entry -> !entry.isDirectory() && entry.getName().endsWith(".class"))
+                        .map(ZipEntry::getName);
+            } catch (IOException e) {
+                return Stream.empty();
+            }
+        });
     }
 
     public static List<Path> sourceFilesStream(String projectPath) throws IOException {


### PR DESCRIPTION
Attempt a fix for issue 74 by moving downloaded dependencies to the `projectPath/target` folder and add a flag (`--no-clean-dependencies`) to turn off cleanup operations (flag defaults to ~no~ clean up, i.e., there will be an attempt to clean up downloaded dependencies by default, if you want to turn this off, use the `--no-clean-dependencies` flag).