### PR TITLE
Lexical printer error

### DIFF
--- a/src/main/java/com/ibm/cldk/SymbolTable.java
+++ b/src/main/java/com/ibm/cldk/SymbolTable.java
@@ -11,6 +11,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.printer.DefaultPrettyPrinter;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodLikeDeclaration;
@@ -554,7 +555,15 @@ public class SymbolTable {
         callableNode.setStartLine(callableDecl.getRange().isPresent() ? callableDecl.getRange().get().begin.line : -1);
         callableNode.setEndLine(callableDecl.getRange().isPresent() ? callableDecl.getRange().get().end.line : -1);
         callableNode.setReferencedTypes(getReferencedTypes(body));
-        callableNode.setCode(body.isPresent() ? LexicalPreservingPrinter.print(body.get()) : "");
+        try {
+            callableNode.setCode(body.isPresent() ? LexicalPreservingPrinter.print(body.get()) : "");
+        } catch (UnsupportedOperationException uoe) {
+            Log.warn("LexicalPreservingPrinter.print() failed on method " + callableDecl.getSignature() +
+                    " of type "+typeName);
+            Log.warn("Reverting to default printing");
+            Log.warn(body.get().toString());
+            callableNode.setCode(body.get().toString());
+        }
         callableNode.setCodeStartLine(body.isPresent()? body.get().getBegin().get().line : -1);
 
         callableNode.setAccessedFields(getAccessedFields(body, classFields, typeName));

--- a/src/test/java/com/ibm/cldk/SymbolTableTest.java
+++ b/src/test/java/com/ibm/cldk/SymbolTableTest.java
@@ -57,6 +57,17 @@ public class SymbolTableTest {
     }
 
     @Test
+    public void testExtractSingleDefaultKeywordMethodDecl() throws IOException {
+        String javaCode = getJavaCodeForTestResource("test-applications/default-keyword-method-decl/IndexExtractor.java");
+        Map<String, JavaCompilationUnit> symbolTable = SymbolTable.extractSingle(javaCode).getLeft();
+        Assertions.assertEquals(1, symbolTable.size());
+        Map<String, Type> typeDeclaration = symbolTable.values().iterator().next().getTypeDeclarations();
+        Assertions.assertEquals(1, typeDeclaration.size());
+        Map<String, Callable> callables = typeDeclaration.values().iterator().next().getCallableDeclarations();
+        Assertions.assertEquals(5, callables.size());
+    }
+
+    @Test
     public void testCallSiteArgumentExpression() throws IOException {
         String javaCode = getJavaCodeForTestResource("test-applications/generics-varargs-duplicate-signature-test/Validate.java");
         Map<String, Type> typeDeclaration = SymbolTable.extractSingle(javaCode).getLeft()

--- a/src/test/resources/test-applications/default-keyword-method-decl/IndexExtractor.java
+++ b/src/test/resources/test-applications/default-keyword-method-decl/IndexExtractor.java
@@ -1,0 +1,160 @@
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Objects;
+import java.util.function.IntPredicate;
+import java.util.function.LongPredicate;
+
+/**
+ * An object that produces indices of a Bloom filter.
+ * <p><em>
+ * The default implementation of {@code asIndexArray} is slow. Implementers should reimplement the
+ * method where possible.</em></p>
+ *
+ * @since 4.5.0-M2
+ */
+@FunctionalInterface
+public interface IndexExtractor {
+
+    /**
+     * Creates an IndexExtractor from a {@code BitMapExtractor}.
+     *
+     * @param bitMapExtractor the {@code BitMapExtractor}
+     * @return a new {@code IndexExtractor}.
+     */
+    static IndexExtractor fromBitMapExtractor(final BitMapExtractor bitMapExtractor) {
+        Objects.requireNonNull(bitMapExtractor, "bitMapExtractor");
+        return consumer -> {
+            final LongPredicate longPredicate = new LongPredicate() {
+                int wordIdx;
+
+                @Override
+                public boolean test(long word) {
+                    int i = wordIdx;
+                    while (word != 0) {
+                        if ((word & 1) == 1 && !consumer.test(i)) {
+                            return false;
+                        }
+                        word >>>= 1;
+                        i++;
+                    }
+                    wordIdx += 64;
+                    return true;
+                }
+            };
+            return bitMapExtractor.processBitMaps(longPredicate::test);
+        };
+    }
+
+    /**
+     * Creates an IndexExtractor from an array of integers.
+     *
+     * @param values the index values
+     * @return an IndexExtractor that uses the values.
+     */
+    static IndexExtractor fromIndexArray(final int... values) {
+        return new IndexExtractor() {
+
+            @Override
+            public int[] asIndexArray() {
+                return values.clone();
+            }
+
+            @Override
+            public boolean processIndices(final IntPredicate predicate) {
+                for (final int value : values) {
+                    if (!predicate.test(value)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        };
+    }
+
+    /**
+     * Return a copy of the IndexExtractor data as an int array.
+     *
+     * <p>Indices ordering and uniqueness is not guaranteed.</p>
+     *
+     * <p><em>
+     * The default implementation of this method creates an array and populates
+     * it.  Implementations that have access to an index array should consider
+     * returning a copy of that array if possible.
+     * </em></p>
+     *
+     * @return An int array of the data.
+     */
+    default int[] asIndexArray() {
+        final class Indices {
+            private int[] data = new int[32];
+            private int size;
+
+            boolean add(final int index) {
+                data = IndexUtils.ensureCapacityForAdd(data, size);
+                data[size++] = index;
+                return true;
+            }
+
+            int[] toArray() {
+                // Edge case to avoid a large array copy
+                return size == data.length ? data : Arrays.copyOf(data, size);
+            }
+        }
+        final Indices indices = new Indices();
+        processIndices(indices::add);
+        return indices.toArray();
+    }
+
+    /**
+     * Each index is passed to the predicate. The predicate is applied to each
+     * index value, if the predicate returns {@code false} the execution is stopped, {@code false}
+     * is returned, and no further indices are processed.
+     *
+     * <p>Any exceptions thrown by the action are relayed to the caller.</p>
+     *
+     * <p>Indices ordering and uniqueness is not guaranteed.</p>
+     *
+     * @param predicate the action to be performed for each non-zero bit index.
+     * @return {@code true} if all indexes return true from consumer, {@code false} otherwise.
+     * @throws NullPointerException if the specified action is null
+     */
+    boolean processIndices(IntPredicate predicate);
+
+    /**
+     * Creates an IndexExtractor comprising the unique indices for this extractor.
+     *
+     * <p>By default creates a new extractor with some overhead to remove
+     * duplicates.  IndexExtractors that return unique indices by default
+     * should override this to return {@code this}.</p>
+     *
+     * <p>The default implementation will filter the indices from this instance
+     * and return them in ascending order.</p>
+     *
+     * @return the IndexExtractor of unique values.
+     * @throws IndexOutOfBoundsException if any index is less than zero.
+     */
+    default IndexExtractor uniqueIndices() {
+        final BitSet bitSet = new BitSet();
+        processIndices(i -> {
+            bitSet.set(i);
+            return true;
+        });
+
+        return new IndexExtractor() {
+            @Override
+            public boolean processIndices(final IntPredicate predicate) {
+                for (int idx = bitSet.nextSetBit(0); idx >= 0; idx = bitSet.nextSetBit(idx + 1)) {
+                    if (!predicate.test(idx)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            @Override
+            public IndexExtractor uniqueIndices() {
+                return this;
+            }
+        };
+    }
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
## Motivation and Context
Fixes lexical preserving printer error that occurs with use of the `default` keyword.

## How Has This Been Tested?
Added test case and input for the fix.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [Codellm-Devkit Documentation](https://codellm-devkit.info)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
