### PR TITLE
feat: emit per-variable field initializers in field declarations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.3.7
+version=2.3.8

--- a/src/main/java/com/ibm/cldk/SymbolTable.java
+++ b/src/main/java/com/ibm/cldk/SymbolTable.java
@@ -714,6 +714,15 @@ public class SymbolTable {
         field.setVariables(
                 fieldDecl.getVariables().stream().map(v -> v.getName().asString()).collect(Collectors.toList()));
 
+        // add variable initializers, keyed per variable (one declaration may flatten multiple declarators)
+        field.setVariableInitializers(fieldDecl.getVariables().stream()
+                .filter(v -> v.getInitializer().isPresent())
+                .collect(Collectors.toMap(
+                        v -> v.getName().asString(),
+                        v -> v.getInitializer().get().toString(),
+                        (a, b) -> a,
+                        LinkedHashMap::new)));
+
         // add field modifiers
         field.setModifiers(
                 fieldDecl.getModifiers().stream().map(m -> m.toString().strip()).collect(Collectors.toList()));

--- a/src/main/java/com/ibm/cldk/entities/Field.java
+++ b/src/main/java/com/ibm/cldk/entities/Field.java
@@ -1,6 +1,7 @@
 package com.ibm.cldk.entities;
 
 import java.util.List;
+import java.util.Map;
 import lombok.Data;
 
 @Data
@@ -13,4 +14,5 @@ public class Field {
     private List<String> variables;
     private List<String> modifiers;
     private List<String> annotations;
+    private Map<String, String> variableInitializers;
 }

--- a/src/test/java/com/ibm/cldk/SymbolTableTest.java
+++ b/src/test/java/com/ibm/cldk/SymbolTableTest.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.ibm.cldk.entities.CallSite;
 import com.ibm.cldk.entities.Callable;
+import com.ibm.cldk.entities.Field;
 import com.ibm.cldk.entities.Import;
 import com.ibm.cldk.entities.JavaCompilationUnit;
 import com.ibm.cldk.entities.Type;
@@ -118,6 +119,38 @@ public class SymbolTableTest {
             Assertions.assertTrue(serializedImportObject.has("is_static"));
             Assertions.assertTrue(serializedImportObject.has("is_wildcard"));
         }
+    }
+
+    @Test
+    public void testExtractSingleFieldInitializers() throws IOException {
+        String javaCode = String.join("\n",
+                "class T {",
+                "    private static final String QUOTES_PATH = \"/rest/quotes\";",
+                "    private int count;",
+                "    private int first = 1, second, third = first + 2;",
+                "}");
+        Map<String, JavaCompilationUnit> symbolTable = SymbolTable.extractSingle(javaCode).getLeft();
+        Assertions.assertEquals(1, symbolTable.size());
+        List<Field> fields = symbolTable.values().iterator().next().getTypeDeclarations()
+                .values().iterator().next().getFieldDeclarations();
+        Assertions.assertEquals(3, fields.size());
+
+        Field quotesPath = fields.get(0);
+        Assertions.assertEquals(List.of("QUOTES_PATH"), quotesPath.getVariables());
+        Assertions.assertEquals(Map.of("QUOTES_PATH", "\"/rest/quotes\""), quotesPath.getVariableInitializers());
+
+        Field count = fields.get(1);
+        Assertions.assertEquals(List.of("count"), count.getVariables());
+        Assertions.assertTrue(count.getVariableInitializers().isEmpty());
+
+        Field multi = fields.get(2);
+        Assertions.assertEquals(List.of("first", "second", "third"), multi.getVariables());
+        Assertions.assertEquals(Map.of("first", "1", "third", "first + 2"), multi.getVariableInitializers());
+
+        JsonObject serializedField = JsonParser.parseString(CodeAnalyzer.gson.toJson(quotesPath)).getAsJsonObject();
+        Assertions.assertTrue(serializedField.has("variable_initializers"));
+        Assertions.assertEquals("\"/rest/quotes\"",
+                serializedField.getAsJsonObject("variable_initializers").get("QUOTES_PATH").getAsString());
     }
 
     private static void assertImport(List<Import> imports, String path, boolean isStatic, boolean isWildcard) {


### PR DESCRIPTION
Added a `variable_initializers` field to the `Field` entity that records each declared variable's field expression as source text.

## Motivation and Context
Field initializers were not included in the old model, so constant values were unrecoverable by consumers, even though JavaParser already exposes them. I added a new field which maps each variable name to its initializer expression, and left the expression text unprocessed so interpretation can be done maximally by downstream consumers.

## How Has This Been Tested?
There's a new test case in the `SymbolTableTest` class which covers various types of field declarations. 

## Breaking Changes
There should be no breaking changes. The changes are purely additive.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [Codellm-Devkit Documentation](https://codellm-devkit.info)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
I bumped the version to 2.3.8. I also used a `LinkedHashMap` to preserve insertion order, so the initializers should serialize in declaration order deterministically. 