### PR TITLE
ci: cross-build macOS x86_64 on Apple Silicon; drop Windows

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -88,23 +88,23 @@ jobs:
             musl: true
             experimental: true
           # ---- macOS --------------------------------------------------------
+          # GitHub retired the Intel (macos-13) hosted runners, so the x86_64
+          # wheel is cross-built on Apple Silicon: we install an x86_64 GraalVM
+          # and run native-image under Rosetta 2, which emits an x86_64 binary
+          # and x86_64 jmods. (GraalVM native-image has no true cross-target.)
           - name: macos-x86_64
-            runs-on: macos-13
+            runs-on: macos-14
             arch: x64
+            graal_arch: macos-x64
             wheel_platform: macosx_11_0_x86_64
             macos_target: "11.0"
             musl: false
+            rosetta: true
           - name: macos-arm64
             runs-on: macos-14
             arch: arm64
             wheel_platform: macosx_11_0_arm64
             macos_target: "11.0"
-            musl: false
-          # ---- Windows ------------------------------------------------------
-          - name: windows-x86_64
-            runs-on: windows-2022
-            arch: x64
-            wheel_platform: win_amd64
             musl: false
 
     steps:
@@ -138,20 +138,40 @@ jobs:
           echo "JAVA_HOME=/opt/graalvm" >> "$GITHUB_ENV"
           echo "/opt/graalvm/bin" >> "$GITHUB_PATH"
 
-      - name: Set up GraalVM (macOS / Windows)
-        if: runner.os != 'Linux'
+      # Native arm64 GraalVM for the macos-arm64 leg. Skipped for the x86_64
+      # cross-build, which installs an x86_64 GraalVM by hand below.
+      - name: Set up GraalVM (macOS arm64)
+        if: runner.os == 'macOS' && matrix.rosetta != true
         uses: graalvm/setup-graalvm@v1
         with:
           java-version: "21"
           distribution: graalvm-community
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up MSVC (Windows)
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
+      # macOS x86_64 cross-build: Rosetta 2 lets the x86_64 GraalVM (and the
+      # native-image it drives) run on the Apple Silicon runner.
+      - name: Install Rosetta 2 (macOS x86_64 cross-build)
+        if: matrix.rosetta
+        shell: bash
+        run: softwareupdate --install-rosetta --agree-to-license
 
-      - name: Set up Python (macOS / Windows)
-        if: runner.os != 'Linux'
+      - name: Install GraalVM x86_64 (macOS x86_64 cross-build)
+        if: matrix.rosetta
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAALVM_VERSION}/graalvm-community-jdk-${GRAALVM_VERSION}_${{ matrix.graal_arch }}_bin.tar.gz"
+          echo "Downloading $url"
+          mkdir -p "$RUNNER_TEMP/graalvm"
+          # macOS tarballs nest the JDK under <top>/Contents/Home; strip the top.
+          curl -fsSL "$url" | tar -xz -C "$RUNNER_TEMP/graalvm" --strip-components=1
+          home="$RUNNER_TEMP/graalvm/Contents/Home"
+          test -x "$home/bin/native-image" || "$home/bin/gu" install native-image || true
+          echo "JAVA_HOME=$home" >> "$GITHUB_ENV"
+          echo "$home/bin" >> "$GITHUB_PATH"
+
+      - name: Set up Python (macOS)
+        if: runner.os == 'macOS'
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -169,7 +189,13 @@ jobs:
         run: |
           set -euo pipefail
           chmod +x ./gradlew || true
-          ./gradlew --no-daemon clean nativeCompile
+          # On the x86_64 leg, run the whole build under Rosetta so the x86_64
+          # GraalVM (JAVA_HOME) drives native-image and emits an x86_64 binary.
+          if [ "${{ matrix.rosetta }}" = "true" ]; then
+            arch -x86_64 ./gradlew --no-daemon clean nativeCompile
+          else
+            ./gradlew --no-daemon clean nativeCompile
+          fi
 
       - name: Build wheel
         shell: bash
@@ -183,9 +209,7 @@ jobs:
           else
             PY=python3
           fi
-          BIN="$PWD/build/native/nativeCompile/codeanalyzer"
-          [ -f "$BIN" ] || BIN="$PWD/build/native/nativeCompile/codeanalyzer.exe"
-          export CODEANALYZER_NATIVE_BINARY="$BIN"
+          export CODEANALYZER_NATIVE_BINARY="$PWD/build/native/nativeCompile/codeanalyzer"
           export CODEANALYZER_JMODS_DIR="$JAVA_HOME/jmods"
           echo "binary:   $CODEANALYZER_NATIVE_BINARY"
           echo "jmods:    $CODEANALYZER_JMODS_DIR"


### PR DESCRIPTION
## Why

The `v2.3.7` **PyPI Release** run hung for ~54 min and had to be cancelled. Two problems:

1. **`macos-x86_64` stuck queued forever** — it targeted `runs-on: macos-13`, the Intel hosted runner image GitHub has retired. No runner is ever assigned, so the job (and the whole run) never completes.
2. **`windows-x86_64` build failed** — `hatch_build.py` looks for `codeanalyzer`, but GraalVM emits `codeanalyzer.exe` on Windows:
   ```
   RuntimeError: CODEANALYZER_NATIVE_BINARY is set to '.../codeanalyzer' but no file exists there.
   ```

(The `musllinux-*` legs also failed at musl-toolchain setup, but those are `experimental: true`/`continue-on-error` and out of scope here.)

## What

- **macOS x86_64 → cross-build on Apple Silicon.** Retarget the leg to `macos-14`, install an x86_64 GraalVM by hand, and run `native-image` under Rosetta 2 (`arch -x86_64`). The x86_64 toolchain emits an x86_64 binary + x86_64 jmods. GraalVM native-image has no true arm64→x86_64 cross-target, so Rosetta is the supported path.
- **Drop Windows entirely** — removes the `windows-x86_64` matrix leg, the MSVC setup step, and the now-unused `.exe` binary fallback.

## Notes

- The arm64 leg keeps using `graalvm/setup-graalvm`; the GraalVM step is now gated to `runner.os == 'macOS' && matrix.rosetta != true`.
- Smoke test of the x86_64 wheel runs the binary via Rosetta on the arm64 host.
- After merge, re-tagging (e.g. `v2.3.8`) will exercise the full publish path. The original `v2.3.7` run was cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)