### PR TITLE
ci: make musl toolchain/zlib downloads resilient to musl.cc outages

### DIFF
--- a/.github/scripts/setup-musl.sh
+++ b/.github/scripts/setup-musl.sh
@@ -21,9 +21,30 @@ esac
 PREFIX=/opt/musl
 mkdir -p "$PREFIX"
 
-toolchain_url="https://musl.cc/${MUSL_TRIPLE}-native.tgz"
-echo "setup-musl: downloading toolchain $toolchain_url"
-curl -fsSL "$toolchain_url" | tar -xz -C "$PREFIX" --strip-components=1
+# Download a file, trying each mirror in turn with retries. musl.cc is chronic-
+# ally flaky (the first release run died on "connect to musl.cc timed out"), so
+# a GitHub-hosted mirror is tried first — GitHub is reliably reachable from CI.
+# `--retry-all-errors` is avoided on purpose: the manylinux_2_28 container ships
+# curl 7.61, which predates that flag. Plain `--retry` covers transient timeouts.
+fetch() {
+  dest="$1"; shift
+  for url in "$@"; do
+    echo "setup-musl: fetching $url"
+    if curl -fL --retry 5 --retry-delay 3 --connect-timeout 20 --max-time 600 \
+            -o "$dest" "$url"; then
+      return 0
+    fi
+    echo "setup-musl: mirror failed, trying next" >&2
+  done
+  echo "setup-musl: all mirrors failed for ${dest##*/}" >&2
+  return 1
+}
+
+toolchain_tgz="$(mktemp --suffix=.tgz)"
+fetch "$toolchain_tgz" \
+  "https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/${MUSL_TRIPLE}-native.tgz" \
+  "https://musl.cc/${MUSL_TRIPLE}-native.tgz"
+tar -xzf "$toolchain_tgz" -C "$PREFIX" --strip-components=1
 
 export PATH="$PREFIX/bin:$PATH"
 echo "$PREFIX/bin" >> "$GITHUB_PATH"
@@ -33,7 +54,12 @@ echo "$PREFIX/bin" >> "$GITHUB_PATH"
 ZLIB_VERSION=1.3.1
 workdir="$(mktemp -d)"
 echo "setup-musl: building static zlib ${ZLIB_VERSION} with ${MUSL_TRIPLE}-gcc"
-curl -fsSL "https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz" | tar -xz -C "$workdir" --strip-components=1
+zlib_tgz="$(mktemp --suffix=.tar.gz)"
+fetch "$zlib_tgz" \
+  "https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz" \
+  "https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz" \
+  "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz"
+tar -xzf "$zlib_tgz" -C "$workdir" --strip-components=1
 (
   cd "$workdir"
   CC="${MUSL_TRIPLE}-gcc" ./configure --static --prefix="$PREFIX"


### PR DESCRIPTION
Follow-up to #147 (which merged before this commit landed).

## Why
The `musllinux-x86_64` / `musllinux-aarch64` legs of the first release run failed at *Set up musl toolchain*:
```
curl: (7) Failed to connect to musl.cc port 443: Connection timed out
```
`musl.cc` is chronically unreliable.

## What
`setup-musl.sh` now downloads via a `fetch()` helper that tries mirrors in order with `curl --retry`:
- **musl toolchain:** `musl-cc/musl.cc` GitHub release (reliable from CI) → `musl.cc`. The mirror is byte-for-byte the same `-native.tgz` layout, so `--strip-components=1`, the `CC` name, and PATH are unchanged.
- **zlib:** `madler/zlib` GitHub release → `zlib.net` → `zlib.net/fossils`.

Avoids `--retry-all-errors` on purpose: the `manylinux_2_28` container ships curl 7.61, which predates that flag.

These legs remain `experimental: true` / `continue-on-error` — a flaky upstream shouldn't block a PyPI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)