### PR TITLE
ci: fix musl static-PIE link + macOS x86_64 cross-wheel smoke test

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -219,10 +219,22 @@ jobs:
           ls -l "$PWD/dist"
 
       - name: Smoke test wheel
+        if: matrix.rosetta != true
         shell: bash
         env:
           PYTHON: ${{ runner.os == 'Linux' && '/opt/python/cp312-cp312/bin/python' || 'python3' }}
         run: bash .github/scripts/smoke-test.sh dist
+
+      # The cross-built x86_64 wheel can't be installed by the runner's arm64
+      # Python. Run the whole smoke test under Rosetta with the universal
+      # /usr/bin/python3, so the venv, pip install, and bundled native binary
+      # all execute as x86_64.
+      - name: Smoke test wheel (x86_64 via Rosetta)
+        if: matrix.rosetta
+        shell: bash
+        env:
+          PYTHON: /usr/bin/python3
+        run: arch -x86_64 bash .github/scripts/smoke-test.sh dist
 
       - name: Checksums (log only)
         shell: bash

--- a/build.gradle
+++ b/build.gradle
@@ -208,6 +208,12 @@ graalvmNative {
             if (System.getenv("CODEANALYZER_NATIVE_MUSL") == "true") {
                 buildArgs.add("--static")
                 buildArgs.add("--libc=musl")
+                // The musl.cc gcc 11 toolchain is built with
+                // --enable-default-pie/--enable-static-pie, so a plain `-static`
+                // link produces a static-PIE. The linker then rejects GraalVM's
+                // image heap ("read-only segment has dynamic relocations" on
+                // .svm_heap). Force a classic non-PIE static executable.
+                buildArgs.add("-H:NativeLinkerOption=-no-pie")
             }
             buildArgs.add("-H:ReflectionConfigurationFiles=$projectDir/src/main/resources/META-INF/native-image-config/reflect-config.json")
             buildArgs.add("-H:ResourceConfigurationFiles=$projectDir/src/main/resources/META-INF/native-image-config/resource-config.json")


### PR DESCRIPTION
Follow-ups surfaced by the re-tagged `v2.3.7` run (#147/#148 already merged).

## musl: `read-only segment has dynamic relocations`
The musl.cc download fix (#148) worked — the toolchain now downloads and native-image runs. It exposed the next error: the musl.cc gcc 11 toolchain is built with `--enable-default-pie/--enable-static-pie`, so `-static` yields a static-PIE that the linker rejects against GraalVM's `.svm_heap`. Add `-H:NativeLinkerOption=-no-pie` to the musl build args to force a classic non-PIE static executable. (musl legs remain `experimental`.)

## macOS x86_64: smoke test on cross-built wheel
The wheel builds fine, but the runner's **arm64** Python can't install an **x86_64**-tagged wheel (`not a supported wheel on this platform`). Run that leg's smoke test under Rosetta with the universal `/usr/bin/python3`, so the venv, `pip install`, and bundled native binary all execute as x86_64 — keeping real validation rather than skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)