### PR TITLE
fix: relativize source root path before applying exclusion filter

### DIFF
--- a/src/main/java/com/ibm/cldk/SymbolTable.java
+++ b/src/main/java/com/ibm/cldk/SymbolTable.java
@@ -1162,9 +1162,10 @@ public class SymbolTable {
             Paths.get("src", "it", "resources").toString(),
             Paths.get("src", "xdocs-examples").toString()
     };
-    private static boolean excludeSourceRoot(Path sourceRoot) {
+    private static boolean excludeSourceRoot(Path sourceRoot, Path projectRootPath) {
+        Path relativeSourceRoot = projectRootPath.toAbsolutePath().relativize(sourceRoot.toAbsolutePath());
         for (String excludedSrcRoot : EXCLUDED_SOURCE_ROOTS) {
-            if (Pattern.compile(excludedSrcRoot).matcher(sourceRoot.toString()).find()) {
+            if (Pattern.compile(excludedSrcRoot).matcher(relativeSourceRoot.toString()).find()) {
                 return true;
             }
         }
@@ -1202,7 +1203,7 @@ public class SymbolTable {
         Map<String, JavaCompilationUnit> symbolTable = new LinkedHashMap<>();
         Map<String, List<Problem>> parseProblems = new HashMap<>();
         for (SourceRoot sourceRoot : projectRoot.getSourceRoots()) {
-            if (excludeSourceRoot(sourceRoot.getRoot())) {
+            if (excludeSourceRoot(sourceRoot.getRoot(), projectRootPath)) {
                 continue;
             }
             sourceRoot.setParserConfiguration(config);


### PR DESCRIPTION
## Motivation and Context

When running CodeAnalyzer with `-i ./src/test/resources/test-applications/daytrader8 -a 1`, the output was always an empty symbol table (`"symbol_table": {}`), even though the project contained valid Java sources under `src/main/java`.

The root cause was in `SymbolTable.excludeSourceRoot`: it matched the exclusion patterns (`src/test/resources`, `src/it/resources`, `src/xdocs-examples`) against the full absolute path of each discovered source root. When the target project is located anywhere under a directory that contains `src/test/resources` in its absolute path — as is the case for test fixtures stored inside this repo — every source root matched the exclusion filter and was skipped entirely.

## How Has This Been Tested?

- Ran `CodeAnalyzer -i ./src/test/resources/test-applications/daytrader8 -a 1` before and after the fix. Before: `"symbol_table": {}`. After: all 40+ daytrader8 source files appear in the symbol table.
- All existing unit and integration tests pass (`./gradlew test` — BUILD SUCCESSFUL).

## Breaking Changes

None. The fix only changes what path string is matched against the exclusion patterns (relative vs. absolute); the set of excluded roots within a target project is unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have read the [Codellm-Devkit Documentation](https://codellm-devkit.info)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
