### PR TITLE
ci(release): announce releases in repo and org discussions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ on:
       - "v*.*.*"
 
 permissions:
-  contents: write 
+  contents: write
+  discussions: write  # attach the release-linked repo Discussion (Announcements)
 
 jobs:
   release:
@@ -104,5 +105,38 @@ jobs:
             release-assets/schema.neo4j.json
             release-assets/codeanalyzer-installer.sh
           body_path: release-notes.md
+          # Auto-open a repo-level Discussion linked to this release, seeded with
+          # the same notes. Requires Discussions enabled and this category to exist.
+          discussion_category_name: Announcements
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Mirror the release announcement into the ORG-level discussions, which are
+      # backed by codellm-devkit/.github. GITHUB_TOKEN can't write cross-repo, so
+      # this uses a PAT (ORG_DISCUSSIONS_TOKEN) with repo scope, and posts via the
+      # createDiscussion GraphQL mutation. Reuses the already-composed release-notes.md
+      # so org and repo posts stay identical.
+      - name: Announce in org-level discussions (codellm-devkit/.github)
+        continue-on-error: true   # a failed org post must not fail an otherwise-good release
+        env:
+          GH_TOKEN: ${{ secrets.ORG_DISCUSSIONS_TOKEN }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -uo pipefail
+          OWNER="codellm-devkit"; REPO=".github"; CATEGORY="Announcements"
+          # The mutation needs GraphQL node IDs, not names — resolve them first.
+          RESP=$(gh api graphql \
+            -f query='query($o:String!,$r:String!){repository(owner:$o,name:$r){id discussionCategories(first:25){nodes{id name}}}}' \
+            -f o="$OWNER" -f r="$REPO") \
+            || { echo "::warning::org discussion lookup failed — skipping org announcement."; exit 0; }
+          REPO_ID=$(echo "$RESP" | jq -r '.data.repository.id')
+          CAT_ID=$(echo "$RESP" | jq -r --arg c "$CATEGORY" '.data.repository.discussionCategories.nodes[]|select(.name==$c)|.id')
+          if [[ -z "$REPO_ID" || "$REPO_ID" == "null" || -z "$CAT_ID" ]]; then
+            echo "::warning::could not resolve $OWNER/$REPO discussion category '$CATEGORY' — skipping org announcement."
+            exit 0
+          fi
+          gh api graphql \
+            -f query='mutation($rid:ID!,$cid:ID!,$t:String!,$b:String!){createDiscussion(input:{repositoryId:$rid,categoryId:$cid,title:$t,body:$b}){discussion{url}}}' \
+            -f rid="$REPO_ID" -f cid="$CAT_ID" \
+            -f t="codeanalyzer-java v$VERSION" \
+            -f b="$(cat release-notes.md)"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.4.1
+version=2.4.2


### PR DESCRIPTION
Closes #166.

## What
Post each release to GitHub Discussions in **two** places (parity with `codeanalyzer-typescript`/`-python`):

- **Repo-level** — add `discussion_category_name: Announcements` to the existing `action-gh-release@v3` publish step, plus `discussions: write` to the workflow `permissions:` block (the restrictive block otherwise denies the release-linked discussion with a misleading "valid category name" error). Seeded from the composed `release-notes.md`.
- **Org-level** — new `continue-on-error` step posting the same body into `codellm-devkit/.github` → **Announcements** via a `createDiscussion` GraphQL mutation, authenticated by `ORG_DISCUSSIONS_TOKEN`.

Also bumps `gradle.properties` `2.4.1 → 2.4.2` so the next tag actually exercises this.

## Prerequisites (already done)
- Discussions enabled + `Announcements` category on this repo.
- `ORG_DISCUSSIONS_TOKEN` has `repo` scope.